### PR TITLE
fix for issue#2 - "ModuleNotFoundError: No module named 'stuff'"

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family = xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,9 @@
 junit_family = xunit2
 markers =
   accumulator
+  acme_bank
   api
   duckduckgo
   math
+  ui
 testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 junit_family = xunit2
+markers =
+  accumulator
+  math
+testpaths = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,7 @@
 junit_family = xunit2
 markers =
   accumulator
+  api
+  duckduckgo
   math
 testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pytest==7.3.1
 pytest-cov==4.0.0
 pytest-html==3.2.0
+pytest-playwright==0.3.3
 pytest-xdist==3.3.1
 requests==2.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 pytest==7.3.1
+pytest-cov==4.0.0
+pytest-html==3.2.0
+pytest-xdist==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pytest==7.3.1
 pytest-cov==4.0.0
 pytest-html==3.2.0
 pytest-xdist==3.3.1
-requests==2.30.0
+requests==2.31.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest==7.3.1
 pytest-cov==4.0.0
 pytest-html==3.2.0
 pytest-xdist==3.3.1
+requests==2.30.0

--- a/tests/test_accum.py
+++ b/tests/test_accum.py
@@ -12,34 +12,38 @@ from stuff.accum import Accumulator
 
 
 # --------------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------------
+
+@pytest.fixture
+def accum():
+  return Accumulator()
+
+
+# --------------------------------------------------------------------------------
 # Tests
 # --------------------------------------------------------------------------------
 
-def test_accumulator_init():
-  accum = Accumulator()
+def test_accumulator_init(accum):
   assert accum.count == 0
 
 
-def test_accumulator_add_one():
-  accum = Accumulator()
+def test_accumulator_add_one(accum):
   accum.add()
   assert accum.count == 1
 
 
-def test_accumulator_add_three():
-  accum = Accumulator()
+def test_accumulator_add_three(accum):
   accum.add(3)
   assert accum.count == 3
 
 
-def test_accumulator_add_twice():
-  accum = Accumulator()
+def test_accumulator_add_twice(accum):
   accum.add()
   accum.add()
   assert accum.count == 2
 
 
-def test_accumulator_cannot_set_count_directly():
-  accum = Accumulator()
+def test_accumulator_cannot_set_count_directly(accum):
   with pytest.raises(AttributeError, match=r"property 'count' of 'Accumulator' object has no setter") as e:
     accum.count = 10

--- a/tests/test_accum.py
+++ b/tests/test_accum.py
@@ -24,26 +24,31 @@ def accum():
 # Tests
 # --------------------------------------------------------------------------------
 
+@pytest.mark.accumulator
 def test_accumulator_init(accum):
   assert accum.count == 0
 
 
+@pytest.mark.accumulator
 def test_accumulator_add_one(accum):
   accum.add()
   assert accum.count == 1
 
 
+@pytest.mark.accumulator
 def test_accumulator_add_three(accum):
   accum.add(3)
   assert accum.count == 3
 
 
+@pytest.mark.accumulator
 def test_accumulator_add_twice(accum):
   accum.add()
   accum.add()
   assert accum.count == 2
 
 
+@pytest.mark.accumulator
 def test_accumulator_cannot_set_count_directly(accum):
   with pytest.raises(AttributeError, match=r"property 'count' of 'Accumulator' object has no setter") as e:
     accum.count = 10

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,31 @@
+"""
+This module contains basic API tests using requests.
+Their purpose is to show how to use the pytest framework by example.
+"""
+
+# --------------------------------------------------------------------------------
+# Imports
+# --------------------------------------------------------------------------------
+
+import pytest
+import requests
+
+
+# --------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------
+
+@pytest.mark.api
+@pytest.mark.duckduckgo
+def test_duckduckgo_instant_answer_api():
+
+  # Arrange
+  url = 'https://api.duckduckgo.com/?q=python+programming&format=json'
+
+  # Act
+  response = requests.get(url)
+  body = response.json()
+
+  # Assert
+  assert response.status_code == 200
+  assert 'Python' in body['AbstractText']

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -14,6 +14,7 @@ import pytest
 # A most basic test function
 # --------------------------------------------------------------------------------
 
+@pytest.mark.math
 def test_one_plus_one():
   assert 1 + 1 == 2
 
@@ -22,6 +23,7 @@ def test_one_plus_one():
 # A test function to show assertion introspection
 # --------------------------------------------------------------------------------
 
+@pytest.mark.math
 def test_one_plus_two():
   a = 1
   b = 2
@@ -33,6 +35,7 @@ def test_one_plus_two():
 # A test function that verifies an exception
 # --------------------------------------------------------------------------------
 
+@pytest.mark.math
 def test_divide_by_zero():
   with pytest.raises(ZeroDivisionError) as e:
     num = 1 / 0
@@ -53,6 +56,7 @@ products = [
   (2.5, 6.7, 16.75)     # floats
 ]
 
+@pytest.mark.math
 @pytest.mark.parametrize('a, b, product', products)
 def test_multiplication(a, b, product):
   assert a * b == product

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,47 @@
+"""
+This module contains basic UI tests using Playwright.
+Their purpose is to show how to use the pytest framework by example.
+"""
+
+# --------------------------------------------------------------------------------
+# Imports
+# --------------------------------------------------------------------------------
+
+import pytest
+import re
+
+from playwright.sync_api import Page, expect
+
+
+# --------------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------------
+
+@pytest.mark.ui
+@pytest.mark.acme_bank
+def test_acme_bank_login(page: Page):
+
+  # Arrange
+  page.goto('https://demo.applitools.com/')
+
+  # Act
+  page.locator('id=username').fill('andy')
+  page.locator('id=password').fill('i<3pandas')
+  page.locator('id=log-in').click()
+
+  # Assert
+  expect(page.locator('div.logo-w')).to_be_visible()
+  expect(page.locator('ul.main-menu')).to_be_visible()
+  expect(page.get_by_text('Add Account')).to_be_visible()
+  expect(page.get_by_text('Make Payment')).to_be_visible()
+  expect(page.get_by_text('View Statement')).to_be_visible()
+  expect(page.get_by_text('Request Increase')).to_be_visible()
+  expect(page.get_by_text('Pay Now')).to_be_visible()
+
+  warning_msg = re.compile(r'Your nearest branch closes in:( \d+[hms])+')
+  expect(page.locator('id=time')).to_have_text(warning_msg)
+
+  acceptable_statuses = ['Complete', 'Pending', 'Declined']
+  actual_statuses = page.locator('span.status-pill + span').all_text_contents()
+  for status in actual_statuses:
+    assert status in acceptable_statuses


### PR DESCRIPTION
This is what fixed the moduleNotFound error for me; just swapping the initialization file from `/stuff` into `/tests`. 
the aHa moment came after finally reading the "Good Integration Practices" pytest documentation liked in the additional resources section; specifically:
"If you need to have test modules with the same name, as a workaround you might add __init__.py files to your tests folder and subfolders, changing them to packages"